### PR TITLE
hotfix: cmake version to uppercase

### DIFF
--- a/onrobot_rg_control/CMakeLists.txt
+++ b/onrobot_rg_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(version 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(onrobot_rg_control)
 
 find_package(ament_cmake REQUIRED)

--- a/onrobot_rg_description/CMakeLists.txt
+++ b/onrobot_rg_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(version 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(onrobot_rg_description)
 
 find_package(ament_cmake REQUIRED)

--- a/onrobot_rg_gazebo/CMakeLists.txt
+++ b/onrobot_rg_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(version 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(onrobot_rg_gazebo)
 
 find_package(gazebo_ros)

--- a/onrobot_rg_modbus_tcp/CMakeLists.txt
+++ b/onrobot_rg_modbus_tcp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(version 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(onrobot_rg_modbus_tcp)
 
 find_package(ament_cmake REQUIRED)

--- a/onrobot_rg_msgs/CMakeLists.txt
+++ b/onrobot_rg_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(version 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(onrobot_rg_msgs)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update CMakeLists.txt files to use uppercase 'VERSION' in 'cmake_minimum_required' directive.